### PR TITLE
Use HassWebView instead of regular WebView

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -276,6 +276,9 @@ dependencies {
     // Fingerprint Identify
     compile 'com.wei.android.lib:fingerprintidentify:1.2.1'
 
+    // Home Assistant WebView
+    compile 'com.github.sjvc:Home-Assistant-WebView:master-SNAPSHOT'
+
     compile 'joda-time:joda-time:2.9.9'
 
     testCompile 'junit:junit:4.12'

--- a/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/BaseFragment.kt
+++ b/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/BaseFragment.kt
@@ -78,4 +78,8 @@ open class BaseFragment : DaggerFragment() {
     fun handleNetworkDisconnect() {
         (activity as BaseActivity).handleNetworkDisconnect()
     }
+
+    open fun onBackPressed() : Boolean{
+        return false
+    }
 }// Required empty public constructor

--- a/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/activities/MainActivity.kt
@@ -35,7 +35,9 @@ import android.support.v4.view.PagerAdapter
 import android.support.v4.view.ViewPager
 import android.support.v7.app.AlertDialog
 import android.view.View
+import android.view.ViewGroup
 import com.thanksmister.iot.mqtt.alarmpanel.BaseActivity
+import com.thanksmister.iot.mqtt.alarmpanel.BaseFragment
 import com.thanksmister.iot.mqtt.alarmpanel.BuildConfig
 import com.thanksmister.iot.mqtt.alarmpanel.R
 import com.thanksmister.iot.mqtt.alarmpanel.ui.fragments.ControlsFragment
@@ -194,8 +196,9 @@ class MainActivity : BaseActivity(), ViewPager.OnPageChangeListener, ControlsFra
             // If the user is currently looking at the first step, allow the system to handle the
             // Back button. This calls finish() on this activity and pops the back stack.
             super.onBackPressed()
-        } else {
-            // Otherwise, select the previous step.
+        }
+        else if (!(pagerAdapter as MainSlidePagerAdapter).getCurrentFragment()!!.onBackPressed()){
+            // Otherwise, if back key press is not handled by fragment, select the previous step.
             view_pager.currentItem = view_pager.currentItem - 1
         }
     }
@@ -383,6 +386,8 @@ class MainActivity : BaseActivity(), ViewPager.OnPageChangeListener, ControlsFra
     }
 
     private inner class MainSlidePagerAdapter(fm: FragmentManager) : FragmentStatePagerAdapter(fm) {
+        private var currentFragment : BaseFragment? = null
+
         override fun getItem(position: Int): Fragment {
             when (position) {
                 0 -> return MainFragment.newInstance()
@@ -393,5 +398,15 @@ class MainActivity : BaseActivity(), ViewPager.OnPageChangeListener, ControlsFra
         override fun getCount(): Int {
             return 2
         }
+
+        override fun setPrimaryItem(container: ViewGroup, position: Int, `object`: Any) {
+            super.setPrimaryItem(container, position, `object`)
+
+            if (currentFragment != `object`){
+                currentFragment = `object` as BaseFragment
+            }
+        }
+
+        fun getCurrentFragment() = currentFragment
     }
 }

--- a/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/fragments/PlatformFragment.kt
+++ b/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/fragments/PlatformFragment.kt
@@ -34,7 +34,7 @@ import timber.log.Timber
 import javax.inject.Inject
 import android.widget.Toast
 import android.widget.CheckBox
-
+import com.baviux.homeassistant.HassWebView
 
 
 class PlatformFragment : BaseFragment(){
@@ -98,15 +98,21 @@ class PlatformFragment : BaseFragment(){
 
     private fun loadWebPage() {
         if (configuration.hasPlatformModule() && !TextUtils.isEmpty(configuration.webUrl) && webView != null) {
-            val settings = webView.getSettings()
-            settings.setJavaScriptEnabled(true)
             Timber.d("load web url: " + configuration.webUrl)
-            webView.webChromeClient = PlatformWebViewClient()
-            //webView.loadUrl("about:blank")
             webView.loadUrl(configuration.webUrl)
+            webView.setEventHandler { listener!!.navigateAlarmPanel() }
         } else if (webView != null) {
             webView.loadUrl("about:blank")
         }
+    }
+
+    override fun onBackPressed() : Boolean{
+        if (webView == null)
+            return super.onBackPressed()
+
+        webView.goBack()
+
+        return true
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -115,15 +121,6 @@ class PlatformFragment : BaseFragment(){
 
     override fun onDetach() {
         super.onDetach()
-    }
-
-    private inner class PlatformWebViewClient : WebChromeClient() {
-        override fun onProgressChanged(view: WebView?, newProgress: Int) {
-            super.onProgressChanged(view, newProgress)
-            if(newProgress == 100 && parentFragment != null) {
-                // na-da
-            }
-        }
     }
 
     companion object {

--- a/app/src/main/res/layout/fragment_platform.xml
+++ b/app/src/main/res/layout/fragment_platform.xml
@@ -24,7 +24,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <WebView
+    <com.baviux.homeassistant.HassWebView
         android:id="@+id/webView"
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ allprojects {
         jcenter()
         mavenCentral()
         google()
+        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
Use HassWebView (instead of regular WebView) so now password can be saved, administrator options are hidden, and back key behavior is improved.

Hi again! Some days ago I created a simple Android app to use Home Assistant web with some improvements. You can see the project here: [https://github.com/sjvc/Home-Assistant-Launcher](https://github.com/sjvc/Home-Assistant-Launcher)

It's very useful, and [people liked it](https://community.home-assistant.io/t/home-assistant-launcher-for-android/44876), and I think it would be great to use it with your Alarm Panel. So I created an Android view to integrate it with your project: [https://github.com/sjvc/Home-Assistant-WebView](https://github.com/sjvc/Home-Assistant-WebView)

What does HassWebView do compared to the regular WebView in Alarm Panel?
1. Allows the user to save password
2. Hides administrator menu items (so no settings are modified accidentally by other family members)
3. Improves back key behavior as described in project readme file

If you want to, you can make points 2 and/or 3 configurable in settings screen. You can set configuration values to HassWebView like this:

>     mWebView.setAdjustBackKeyBehavior(boolean); // If true, back key behavior will be like described above. Default is true.
>     mWebView.setHideAdminMenuItems(boolean); // If true, administrator menu items will be hidden. Default is true.
