### PR TITLE
HassView now acts as standard WebView when not using Home Assistant

### DIFF
--- a/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/activities/MainActivity.kt
@@ -207,6 +207,10 @@ class MainActivity : BaseActivity(), ViewPager.OnPageChangeListener, ControlsFra
         view_pager.currentItem = 0
     }
 
+    override fun setPagingEnabled(value: Boolean) {
+        view_pager.setPagingEnabled(value)
+    }
+
     override fun navigatePlatformPanel() {
         view_pager.currentItem = 1
     }

--- a/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/fragments/PlatformFragment.kt
+++ b/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/fragments/PlatformFragment.kt
@@ -110,9 +110,7 @@ class PlatformFragment : BaseFragment(){
         if (webView == null)
             return super.onBackPressed()
 
-        webView.goBack()
-
-        return true
+        return webView.onBackPressed()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/fragments/PlatformFragment.kt
+++ b/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/fragments/PlatformFragment.kt
@@ -17,14 +17,11 @@
 package com.thanksmister.iot.mqtt.alarmpanel.ui.fragments
 
 import android.content.Context
-import android.content.DialogInterface
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.webkit.WebChromeClient
-import android.webkit.WebView
 import com.thanksmister.iot.mqtt.alarmpanel.BaseFragment
 import com.thanksmister.iot.mqtt.alarmpanel.R
 import com.thanksmister.iot.mqtt.alarmpanel.ui.Configuration
@@ -32,7 +29,6 @@ import com.thanksmister.iot.mqtt.alarmpanel.utils.DialogUtils
 import kotlinx.android.synthetic.main.fragment_platform.*
 import timber.log.Timber
 import javax.inject.Inject
-import android.widget.Toast
 import android.widget.CheckBox
 import com.baviux.homeassistant.HassWebView
 
@@ -46,6 +42,7 @@ class PlatformFragment : BaseFragment(){
 
     interface OnPlatformFragmentListener {
         fun navigateAlarmPanel()
+        fun setPagingEnabled(value: Boolean)
     }
 
     override fun onAttach(context: Context?) {
@@ -100,7 +97,15 @@ class PlatformFragment : BaseFragment(){
         if (configuration.hasPlatformModule() && !TextUtils.isEmpty(configuration.webUrl) && webView != null) {
             Timber.d("load web url: " + configuration.webUrl)
             webView.loadUrl(configuration.webUrl)
-            webView.setEventHandler { listener!!.navigateAlarmPanel() }
+            webView.setOnFinishEventHandler { listener!!.navigateAlarmPanel() }
+            webView.setMoreInfoDialogHandler(object : HassWebView.IMoreInfoDialogHandler{
+                override fun onShowMoreInfoDialog() {
+                    listener!!.setPagingEnabled(false)
+                }
+                override fun onHideMoreInfoDialog() {
+                    listener!!.setPagingEnabled(true)
+                }
+            })
         } else if (webView != null) {
             webView.loadUrl("about:blank")
         }


### PR DESCRIPTION
I'm sending 2 commits in this pull request:

Now, if a different web than home assistant is used, HassWebView won't do anything related to home assistant, so it should work with every web page.

Also, I realized that due to pager paging, it was impossible to slide some home assistant controls. For example, if you touch a light, a popup will show a slider to choose brightness, and a color wheel to select color. Swiping horizontally does not allow setting a slider position. The same happens for roller shutter sliders. So, I modified it to disable pager paging when a home assistant dialog is shown. When the dialog is closed, paging is enabled again.

If you get any compiler error, you may need to refresh HassWebView dependency. You can refresh it by adding this to your build.gradle, as seen [here](https://github.com/jitpack/jitpack.io): 

```
configurations.all {
    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
}
```

For now I prefer to use dependency as snapshot version I will upload a release version when we are sure everything is working fine, and there is no need for more modifications.