### PR TITLE
Several bug fixes

### DIFF
--- a/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/Configuration.kt
+++ b/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/Configuration.kt
@@ -36,12 +36,12 @@ constructor(private val sharedPreferences: DPreference) {
         set(value) = this.sharedPreferences.setPrefString(PREF_WEB_URL, value)
 
     var hideAdminMenu: Boolean
-        get() = this.sharedPreferences.getPrefBoolean(PREF_PLATFORM_BACK_BEHAVIOR, true)
-        set(value) = this.sharedPreferences.setPrefBoolean(PREF_PLATFORM_BACK_BEHAVIOR, value)
-
-    var adjustBackBehavior: Boolean
         get() = this.sharedPreferences.getPrefBoolean(PREF_PLATFORM_ADMIN_MENU, true)
         set(value) = this.sharedPreferences.setPrefBoolean(PREF_PLATFORM_ADMIN_MENU, value)
+
+    var adjustBackBehavior: Boolean
+        get() = this.sharedPreferences.getPrefBoolean(PREF_PLATFORM_BACK_BEHAVIOR, true)
+        set(value) = this.sharedPreferences.setPrefBoolean(PREF_PLATFORM_BACK_BEHAVIOR, value)
 
     var alarmMode: String
         get() = this.sharedPreferences.getPrefString(PREF_ALARM_MODE, MODE_DISARM)

--- a/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/fragments/PlatformFragment.kt
+++ b/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/fragments/PlatformFragment.kt
@@ -75,6 +75,7 @@ class PlatformFragment : BaseFragment(){
         super.onViewCreated(view, savedInstanceState)
         button_alarm.setOnClickListener({
             if(listener != null) {
+                webView.closeMoreInfoDialog()
                 listener!!.navigateAlarmPanel()
             }
         })
@@ -97,7 +98,7 @@ class PlatformFragment : BaseFragment(){
             webView.loadUrl(configuration.webUrl)
             webView.setAdjustBackKeyBehavior(configuration.adjustBackBehavior)
             webView.setHideAdminMenuItems(configuration.hideAdminMenu)
-            webView.setOnFinishEventHandler { listener!!.navigateAlarmPanel() }
+            webView.setOnFinishEventHandler { button_alarm.callOnClick() }
             webView.setMoreInfoDialogHandler(object : HassWebView.IMoreInfoDialogHandler{
                 override fun onShowMoreInfoDialog() {
                     listener!!.setPagingEnabled(false)
@@ -115,8 +116,15 @@ class PlatformFragment : BaseFragment(){
         if (webView == null) {
             return super.onBackPressed()
         }
-        webView.goBack()
-        return true
+
+        val handled = webView.onBackPressed()
+
+        // If HassWebView doesn't handle it -> ensure no hass dialog is shown and paging is restored
+        if (!handled){
+            webView.closeMoreInfoDialog()
+        }
+
+        return handled;
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/fragments/PlatformSettingsFragment.kt
+++ b/app/src/main/java/com/thanksmister/iot/mqtt/alarmpanel/ui/fragments/PlatformSettingsFragment.kt
@@ -85,8 +85,8 @@ class PlatformSettingsFragment : PreferenceFragmentCompat(), SharedPreferences.O
 
         webModulePreference = findPreference(PREF_MODULE_WEB) as CheckBoxPreference
         platformbarPreference = findPreference(PREF_PLATFORM_BAR) as CheckBoxPreference
-        adminMenuPreference = findPreference(PREF_PLATFORM_BACK_BEHAVIOR) as CheckBoxPreference
-        backBehaviorPreference = findPreference(PREF_PLATFORM_ADMIN_MENU) as CheckBoxPreference
+        adminMenuPreference = findPreference(PREF_PLATFORM_ADMIN_MENU) as CheckBoxPreference
+        backBehaviorPreference = findPreference(PREF_PLATFORM_BACK_BEHAVIOR) as CheckBoxPreference
         webUrlPreference = findPreference(PREF_WEB_URL) as EditTextPreference
 
         if (!TextUtils.isEmpty(configuration.webUrl)) {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -254,8 +254,8 @@
     <string name="pref_hass_settings">Home Assistant Configuraciones</string>
     <string name="pref_hide_menu_title">Ocultar el menú</string>
     <string name="pref_hide_menu_summary">Oculta los elementos del menú de administrador.</string>
-    <string name="pref_back_behavior_title">Anular el comportamiento de la espalda</string>
-    <string name="pref_back_behavior_summary">El botón de Android se comporta como el botón de retroceso del navegador.</string>
+    <string name="pref_back_behavior_title">Modificar el comportamiento del botón volver</string>
+    <string name="pref_back_behavior_summary">El botón volver de Android se comporta como el botón de retroceso del navegador.</string>
     <string name="text_touch_sensor">Sensor tactil</string>
 
     <string-array name="inactivity_times">


### PR DESCRIPTION
Commit 1e3958b
Some assignments were wrong, I fixed them.

Commit 7a6a806
In Spanish "espalda" means "back", but as a body part (I'm native Spanish speaker)

Commit 56ea4c0
Back button behavior now works this way:
- If "Adjust back behavior" is unchecked: pressing back key brings the user back to alarm panel (as it was working before adding HassWebView).
- If "Adjust back behavior" is checked: pressing back key closes dialogs, and brings the user back to "Overview" section if any other is selected. It not behaves exactly like the browser back button (browser back button also navigates through previous visited tabs, but I don't like it because it doesn't feel like a native Android app, it's not useful, and makes going back to alarm panel slower).

Also, when the user goes back from Home Assistant view to Alarm Panel view (either by touching bottom bar button, or pressing back button), if there is a dialog visible, then it will be closed to re-enable paging (remember that it's disabled when a dialog is shown in order to get sliders working).

If you find any bug, please tell me and I'll fix it.

Thanks!