### PR TITLE
Improve design in alarm options dialog

### DIFF
--- a/app/src/main/res/layout-sw600dp/dialog_alarm_options.xml
+++ b/app/src/main/res/layout-sw600dp/dialog_alarm_options.xml
@@ -76,7 +76,8 @@
             android:layout_height="16dp"/>
     
     <LinearLayout
-            android:layout_width="480dp"
+            android:minWidth="480dp"
+            android:layout_width="wrap_content"
             android:layout_height="320dp"
             android:gravity="center|bottom"
             android:orientation="horizontal">


### PR DESCRIPTION
On my tablet it looks like this (only "away" button text is modified for testing purposes):

![image](https://user-images.githubusercontent.com/1282513/38726576-d3ef8024-3f0a-11e8-9b1d-c0f8d61fa0a8.png)

So I modified the layout:

![image](https://user-images.githubusercontent.com/1282513/38726620-f1b4815e-3f0a-11e8-8e04-9be696d17c50.png)
